### PR TITLE
Feature/DAG 1 & 2 Refactoring

### DIFF
--- a/o3/dags/dag1.py
+++ b/o3/dags/dag1.py
@@ -77,8 +77,8 @@ with DAG('o3_d_dag1', default_args=default_args,
                            filepath=_get_t1_filepaths,
                            fs_type='local')
 
-    def _o3_t_summarize(**kwargs):
-        words, rows = kwargs['task_instance'].xcom_pull(
+    def _o3_t_summarize(**ctx):
+        words, rows = ctx['task_instance'].xcom_pull(
             task_ids=['o3_t_count_words', 'o3_t_count_rows'])
         return f'summary: {words} / {rows}'
 

--- a/o3/dags/dag2.py
+++ b/o3/dags/dag2.py
@@ -26,13 +26,14 @@ from pprint import pformat
 from datetime import datetime, timedelta
 
 from airflow import DAG
-from airflow.exceptions import AirflowSkipException
 from airflow.operators.python_operator import PythonOperator
 
 from o3.hooks.hdfs_hook import HDFSHook
 from o3.sensors.hdfs_sensor import HDFSSensor
 from o3.operators.ensure_dir_operator import EnsureDirOperator
 from o3.operators.move_file_operator import MoveFileOperator
+from o3.operators.word_count_operator import WordCountOperator
+from o3.operators.row_count_operator import RowCountOperator
 
 
 default_args = {
@@ -74,36 +75,16 @@ with DAG('o3_d_dag2', default_args=default_args, schedule_interval='@once',
                           max_files=1,
                           depends_on_past=True)
 
-    def _o3_t_count_words(*args, **kwargs):
-        print('_o3_t_count_words', pformat(args), pformat(kwargs))
-        hdfs = HDFSHook().get_conn()
-        process_filepath = kwargs['task_instance'].xcom_pull(
-            task_ids='o3_t_get_input_file')[0]
+    def _get_t1_filepaths(**kwargs):
+        return kwargs['ti'].xcom_pull(task_ids='o3_t_get_input_file')
 
-        sleep(5)
-        with hdfs.open(process_filepath, 'rb') as file_obj:
-            spaces = file_obj.read().decode('utf-8').replace(
-                '\n', ' ').count(' ')
-            return f'counted {spaces + 1} words'
+    t2a = WordCountOperator(task_id='o3_t_count_words',
+                            filepath=_get_t1_filepaths,
+                            fs_type='hdfs')
 
-    t2a = PythonOperator(task_id='o3_t_count_words',
-                         python_callable=_o3_t_count_words,
-                         provide_context=True)
-
-    def _o3_t_count_rows(*args, **kwargs):
-        print('__o3_t_count_rows', pformat(args), pformat(kwargs))
-        hdfs = HDFSHook().get_conn()
-        process_filepath = kwargs['task_instance'].xcom_pull(
-            task_ids='o3_t_get_input_file')[0]
-
-        sleep(10)
-        with hdfs.open(process_filepath, 'rb') as file_obj:
-            rows = len(file_obj.read().decode('utf-8').splitlines())
-            return f'found {rows} rows'
-
-    t2b = PythonOperator(task_id='o3_t_count_rows',
-                         python_callable=_o3_t_count_rows,
-                         provide_context=True)
+    t2b = RowCountOperator(task_id='o3_t_count_rows',
+                           filepath=_get_t1_filepaths,
+                           fs_type='hdfs')
 
     def _o3_t_summarize(*args, **kwargs):
         print('_o3_t_summarize', pformat(args), pformat(kwargs))

--- a/o3/dags/dag2.py
+++ b/o3/dags/dag2.py
@@ -73,8 +73,8 @@ with DAG('o3_d_dag2', default_args=default_args, schedule_interval='@once',
                           max_files=1,
                           depends_on_past=True)
 
-    def _get_t1_filepaths(**kwargs):
-        return kwargs['ti'].xcom_pull(task_ids='o3_t_get_input_file')
+    def _get_t1_filepaths(**ctx):
+        return ctx['ti'].xcom_pull(task_ids='o3_t_get_input_file')
 
     t2a = WordCountOperator(task_id='o3_t_count_words',
                             filepath=_get_t1_filepaths,
@@ -84,10 +84,9 @@ with DAG('o3_d_dag2', default_args=default_args, schedule_interval='@once',
                            filepath=_get_t1_filepaths,
                            fs_type='hdfs')
 
-    def _o3_t_summarize(**kwargs):
-        words, rows = kwargs['task_instance'].xcom_pull(
+    def _o3_t_summarize(**ctx):
+        words, rows = ctx['task_instance'].xcom_pull(
             task_ids=['o3_t_count_words', 'o3_t_count_rows'])
-
         return f'summary: {words} / {rows}'
 
     t3 = PythonOperator(task_id='o3_t_summarize',

--- a/o3/operators/ensure_dir_operator.py
+++ b/o3/operators/ensure_dir_operator.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""Custom operator for making sure the dirs we use sensors on actually exist."""
+
+import os
+
+from airflow.exceptions import AirflowException
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+
+from ..hooks.hdfs_hook import HDFSHook
+
+
+class EnsureDirOperator(BaseOperator):
+    """Ensures a directory exists, locally or in HDFS.
+
+    :param list paths: One or more directory paths that should exist.
+    :param str fs_type: 'local' or 'hdfs'.
+    """
+    ui_color = '#ffefeb'
+
+    @apply_defaults
+    def __init__(self, paths: list, fs_type: str = 'local', *args, **kwargs):
+        super(EnsureDirOperator, self).__init__(*args, **kwargs)
+        if fs_type not in ('local', 'hdfs'):
+            raise AirflowException(f'Unsupported fs_type {fs_type!r}.')
+
+        self.paths = paths
+        self.fs_type = fs_type
+
+    def execute(self, _):
+        if self.fs_type == 'local':
+            for path_ in self.paths:
+                if os.path.isdir(path_):
+                    self.log.debug(f'Local dir {path_} exists.')
+                else:
+                    self.log.info(f'Creating local {path_} dir.')
+                    os.makedirs(path_)
+        else:
+            hdfs = HDFSHook().get_conn()
+            for path_ in self.paths:
+                if hdfs.isdir(path_):
+                    self.log.debug(f'HDFS dir {path_} exists.')
+                else:
+                    self.log.info(f'Creating HDFS {path_} dir.')
+                    hdfs.makedirs(path_)

--- a/o3/operators/ensure_dir_operator.py
+++ b/o3/operators/ensure_dir_operator.py
@@ -27,7 +27,7 @@ class EnsureDirOperator(BaseOperator):
         self.paths = paths
         self.fs_type = fs_type
 
-    def execute(self, _):
+    def execute(self, **_):
         if self.fs_type == 'local':
             for path_ in self.paths:
                 if os.path.isdir(path_):

--- a/o3/operators/move_file_operator.py
+++ b/o3/operators/move_file_operator.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+"""Custom operator for picking up input file after sensor-poke success."""
+
+import os
+import glob
+import shutil
+
+from airflow.exceptions import AirflowException, AirflowSkipException
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+
+from ..hooks.hdfs_hook import HDFSHook
+
+
+class MoveFileOperator(BaseOperator):
+    """Moves file matching glob from src to dest dir, locally or in HDFS.
+
+    :param str glob_pattern: Glob pattern, e.g. '*.txt'.
+    :param str src_dir: Directory path to find file in.
+    :param str dest_dir: Directory to move file into.
+    :param str fs_type: 'local' or 'hdfs'.
+    :param int max_files: Maximum number of files to move.
+    """
+    ui_color = '#ffefeb'
+
+    @apply_defaults
+    def __init__(self, glob_pattern: str, src_dir: str, dest_dir: str,
+                 fs_type: str = 'local', max_files: int = None,
+                 *args, **kwargs):
+        super(MoveFileOperator, self).__init__(*args, **kwargs)
+        if fs_type not in ('local', 'hdfs'):
+            raise AirflowException(f'Unsupported fs_type {fs_type!r}.')
+
+        self.glob_pattern = glob_pattern
+        self.src_dir = src_dir.rstrip('/')
+        self.dest_dir = dest_dir.rstrip('/')
+        self.fs_type = fs_type
+        self.max_files = max_files
+
+    def execute(self, **_) -> list:
+        dest_paths = []
+
+        if self.fs_type == 'local':
+            for src_path in glob.glob(os.path.join(self.src_dir,
+                                                   self.glob_pattern)):
+                dest_path = os.path.join(self.dest_dir,
+                                         os.path.basename(src_path))
+                self.log.info(f'Moving local file {src_path} to {dest_path}.')
+                shutil.move(src_path, dest_path)
+                dest_paths.append(dest_path)
+                if self.max_files and len(dest_paths) >= self.max_files:
+                    break
+        else:
+            hdfs = HDFSHook().get_conn()
+            for src_path in hdfs.glob(os.path.join(self.src_dir,
+                                                   self.glob_pattern)):
+                dest_path = os.path.join(self.dest_dir,
+                                         os.path.basename(src_path))
+                self.log.info(f'Moving HDFS file {src_path} to {dest_path}.')
+                hdfs.mv(src_path, dest_path)
+                dest_paths.append(dest_path)
+                if self.max_files and len(dest_paths) >= self.max_files:
+                    break
+
+        if not dest_paths:
+            self.log.info('No files found, skipping.')
+            raise AirflowSkipException()
+
+        return dest_paths

--- a/o3/operators/row_count_operator.py
+++ b/o3/operators/row_count_operator.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+"""Custom operator for counting rows in a file."""
+
+from airflow.exceptions import AirflowException
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+
+from ..hooks.hdfs_hook import HDFSHook
+
+
+class RowCountOperator(BaseOperator):
+    """Count rows in a file, found locally or in HDFS. Only supports UTF-8.
+
+    :param filepath: File path, list of paths, or callable that produces paths.
+    :param str fs_type: 'local' or 'hdfs'.
+    """
+    ui_color = '#ffefeb'
+
+    @apply_defaults
+    def __init__(self, filepath, fs_type: str = 'local', *args, **kwargs):
+        super(RowCountOperator, self).__init__(*args, **kwargs)
+        if fs_type not in ('local', 'hdfs'):
+            raise AirflowException(f'Unsupported fs_type {fs_type!r}.')
+
+        if isinstance(filepath, list):
+            self.filepath_strs = filepath
+        elif isinstance(filepath, str):
+            self.filepath_strs = [filepath]
+        else:
+            self.filepath_strs = None
+
+        self.filepath_callable = filepath if callable(filepath) else None
+
+        self.fs_type = fs_type
+
+    @staticmethod
+    def _count_rows(text: str) -> str:
+        rows = len(text.splitlines())
+        return f'found {rows} rows'
+
+    def execute(self, context) -> list:
+        row_counts = []
+
+        if self.filepath_strs:
+            filepaths = self.filepath_strs
+        else:
+            filepaths = self.filepath_callable(**context)
+
+        if self.fs_type == 'local':
+            for filepath in filepaths:
+                self.log.debug(f'Reading local file {filepath}')
+                with open(filepath, 'r', encoding='utf-8') as file_obj:
+                    row_counts.append(self._count_rows(file_obj.read()))
+                    self.log.info(f'Processed local file {filepath}: '
+                                  f'{row_counts[-1]}')
+        else:
+            hdfs = HDFSHook().get_conn()
+            for filepath in filepaths:
+                self.log.debug(f'Reading HDFS file {filepath}')
+                with hdfs.open(filepath, 'rb') as file_obj:
+                    row_counts.append(
+                        self._count_rows(file_obj.read().decode('utf-8')))
+                    self.log.info(f'Processed HDFS file {filepath}: '
+                                  f'{row_counts[-1]}')
+
+        if not row_counts:
+            raise AirflowException('No rows counted.')
+
+        return row_counts

--- a/o3/operators/word_count_operator.py
+++ b/o3/operators/word_count_operator.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+"""Custom operator for counting words in a file."""
+
+from airflow.exceptions import AirflowException
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+
+from ..hooks.hdfs_hook import HDFSHook
+
+
+class WordCountOperator(BaseOperator):
+    """Count words in a file, found locally or in HDFS. Only supports UTF-8.
+
+    :param filepath: File path, list of paths, or callable that produces paths.
+    :param str fs_type: 'local' or 'hdfs'.
+    """
+    ui_color = '#ffefeb'
+
+    @apply_defaults
+    def __init__(self, filepath, fs_type: str = 'local', *args, **kwargs):
+        super(WordCountOperator, self).__init__(*args, **kwargs)
+        if fs_type not in ('local', 'hdfs'):
+            raise AirflowException(f'Unsupported fs_type {fs_type!r}.')
+
+        if isinstance(filepath, list):
+            self.filepath_strs = filepath
+        elif isinstance(filepath, str):
+            self.filepath_strs = [filepath]
+        else:
+            self.filepath_strs = None
+
+        self.filepath_callable = filepath if callable(filepath) else None
+
+        self.fs_type = fs_type
+
+    @staticmethod
+    def _count_words(text: str) -> str:
+        spaces = text.replace('\n', ' ').count(' ')
+        return f'counted {spaces + 1} words'
+
+    def execute(self, context) -> list:
+        word_counts = []
+
+        if self.filepath_strs:
+            filepaths = self.filepath_strs
+        else:
+            filepaths = self.filepath_callable(**context)
+
+        if self.fs_type == 'local':
+            for filepath in filepaths:
+                self.log.debug(f'Reading local file {filepath}')
+                with open(filepath, 'r', encoding='utf-8') as file_obj:
+                    word_counts.append(self._count_words(file_obj.read()))
+                    self.log.info(f'Processed local file {filepath}: '
+                                  f'{row_counts[-1]}')
+        else:
+            hdfs = HDFSHook().get_conn()
+            for filepath in filepaths:
+                self.log.debug(f'Reading HDFS file {filepath}')
+                with hdfs.open(filepath, 'rb') as file_obj:
+                    word_counts.append(
+                        self._count_words(file_obj.read().decode('utf-8')))
+                    self.log.info(f'Processed HDFS file {filepath}: '
+                                  f'{row_counts[-1]}')
+
+        if not word_counts:
+            raise AirflowException('No words counted.')
+
+        return word_counts


### PR DESCRIPTION
Everything works the same as in PR #13 and #15, but now all the task specific code in `o3.dags.dag1` and `o3.dags.dag2` PythonOperators have been moved into a series of rather specific custom operators:
* `o3.operators.ensure_dir_operator.EnsureDirOperator`
* `o3.operators.move_file_operator.MoveFileOperator`
* `o3.operators.word_count_operator.WordCountOperator`
* `o3.operators.row_count_operator.RowCountOperator`
* `o3.operators.remove_file_operator.RemoveFileOperator`

... keeping the workflow layout pretty neat and easily graspable:

```python
FILE_INPUT_DIR = path.join('/user/airflow/', 'input')

PROCESSING_DIR = path.join('/user/airflow/', 'processing')


with DAG('o3_d_dag2', default_args=default_args, schedule_interval='@once',
         catchup=False) as dag2:

    t0 = EnsureDirOperator(task_id='o3_t_ensure_dirs_exist',
                           paths=[FILE_INPUT_DIR, PROCESSING_DIR],
                           fs_type='hdfs')

    s0 = HDFSSensor(task_id='o3_s_scan_input_dir',
                    hdfs_conn_id='hdfs_default',
                    filepath=FILE_INPUT_DIR)

    t1 = MoveFileOperator(task_id='o3_t_get_input_file',
                          glob_pattern='*.txt',
                          src_dir=FILE_INPUT_DIR,
                          dest_dir=PROCESSING_DIR,
                          fs_type='hdfs',
                          max_files=1,
                          depends_on_past=True)

    def _get_t1_filepaths(**ctx):
        return ctx['ti'].xcom_pull(task_ids='o3_t_get_input_file')

    t2a = WordCountOperator(task_id='o3_t_count_words',
                            filepath=_get_t1_filepaths,
                            fs_type='hdfs')

    t2b = RowCountOperator(task_id='o3_t_count_rows',
                           filepath=_get_t1_filepaths,
                           fs_type='hdfs')

    def _o3_t_summarize(**ctx):
        words, rows = ctx['task_instance'].xcom_pull(
            task_ids=['o3_t_count_words', 'o3_t_count_rows'])
        return f'summary: {words} / {rows}'

    t3 = PythonOperator(task_id='o3_t_summarize',
                        python_callable=_o3_t_summarize,
                        provide_context=True)

    t4 = RemoveFileOperator(task_id='o3_t_remove_input',
                            filepath=_get_t1_filepaths,
                            fs_type='hdfs')

    # Workflow!
    t0 >> s0 >> t1 >> [t2a, t2b] >> t3 >> t4


```