### PR TITLE
Ensure an interactive login shell is used when wrapping bash in Ansible

### DIFF
--- a/roles/airflow/handlers/main.yml
+++ b/roles/airflow/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: airflow initdb
-  shell: bash -l -c 'source /home/airflow/anaconda3/bin/activate o3 && airflow initdb'
+  shell: bash -ilc 'conda activate o3 && airflow initdb'
   become: yes
   become_user: airflow
   register: airflow_initdb

--- a/roles/airflow/templates/airflow-scheduler.service.j2
+++ b/roles/airflow/templates/airflow-scheduler.service.j2
@@ -7,7 +7,7 @@ EnvironmentFile=/home/airflow/airflow-environment
 User=airflow
 Group=airflow
 Type=simple
-ExecStart=/bin/bash -l -c 'source /home/airflow/anaconda3/bin/activate o3; airflow scheduler'
+ExecStart=/bin/bash -ilc 'conda activate o3 && airflow scheduler'
 RestartSec=5s
 
 [Install]

--- a/roles/airflow/templates/airflow-webserver.service.j2
+++ b/roles/airflow/templates/airflow-webserver.service.j2
@@ -7,7 +7,7 @@ EnvironmentFile=/home/airflow/airflow-environment
 User=airflow
 Group=airflow
 Type=simple
-ExecStart=/bin/bash -l -c 'source /home/airflow/anaconda3/bin/activate o3; airflow webserver -p 8080'
+ExecStart=/bin/bash -ilc 'conda activate o3 && airflow webserver -p 8080'
 RestartSec=5s
 
 [Install]


### PR DESCRIPTION
As can be read in the man bash, ~/.bashrc is only red when an interactive login shell is used. This can be accomplished using the bash -ilc syntax. Where -l ensures a login shell and -i an interactive shell.

This should work on both Ubuntu and CentOS. But only tested on Ubuntu